### PR TITLE
Implement referral id handling

### DIFF
--- a/src/handlers/start.ts
+++ b/src/handlers/start.ts
@@ -1,11 +1,12 @@
-import { Context, Scenes } from 'telegraf';
+import { Context } from 'telegraf';
 import { checkSubscription } from '../utils/checkSubscription';
 import { menuKeyboard } from '../keyboards';
 
 export async function startHandler(ctx: any) {
   if (ctx.startPayload) {
-    ctx.session ??= {};
-    (ctx.session as any).ref = ctx.startPayload;
+    ctx.state ??= {};
+    const match = ctx.startPayload.match(/start_id=([^\s]+)/);
+    ctx.state.referralId = match ? match[1] : ctx.startPayload;
   }
   const subscribed = await checkSubscription(ctx);
   if (!subscribed) {

--- a/src/scenes/partnerSearch.ts
+++ b/src/scenes/partnerSearch.ts
@@ -30,7 +30,11 @@ export const partnerSearchScene = new Scenes.WizardScene<any>(
     (ctx.wizard.state as any).datetime = (ctx.message as any)?.text;
     const summary = `Игра: ${(ctx.wizard.state as any).game}\nВозраст: ${(ctx.wizard.state as any).age}\nСкил: ${(ctx.wizard.state as any).skill}\nКогда: ${(ctx.wizard.state as any).datetime}`;
     await ctx.reply(`Спасибо! Данные отправлены администратору.\n${summary}`);
-    await ctx.telegram.sendMessage(process.env.ADMIN_ID as string, `Новая заявка:\n${summary}\nПользователь: @${(ctx.chat.username)}`);
+    const ref = ctx.state?.referralId ? `\nРеферал: ${ctx.state.referralId}` : '';
+    await ctx.telegram.sendMessage(
+      process.env.ADMIN_ID as string,
+      `Новая заявка:\n${summary}\nПользователь: @${ctx.chat.username}${ref}`
+    );
     return ctx.scene.leave();
   }
 );

--- a/src/utils/checkSubscription.ts
+++ b/src/utils/checkSubscription.ts
@@ -1,6 +1,20 @@
 import { Context } from 'telegraf';
 
-export async function checkSubscription(ctx: Context): Promise<boolean> {
+export async function checkSubscription(ctx: Context & { state: any }): Promise<boolean> {
+  if (!ctx.state.referralId) {
+    let payload: string | undefined;
+    if ("startPayload" in ctx && ctx.startPayload) {
+      payload = ctx.startPayload as unknown as string;
+    } else if ((ctx.message as any)?.text) {
+      const text = (ctx.message as any).text as string;
+      const match = text.match(/^\/start\s+(.+)/);
+      if (match) payload = match[1];
+    }
+    if (payload) {
+      const match = payload.match(/start_id=([^\s]+)/);
+      ctx.state.referralId = match ? match[1] : payload;
+    }
+  }
   const channel = process.env.CHANNEL_USERNAME as string;
   if (!channel) return true;
   try {


### PR DESCRIPTION
## Summary
- capture `start_id` from deep-link and store in `ctx.state`
- parse referral id during subscription check if not present
- include referral info when sending request details to admin

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68723bd0eacc8325919c5fe6c2f821a0