### PR TITLE
Add docker-compose for local PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: playstar
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:

--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,19 @@
 - `referralId` – код реферала.
 
 В файле `.env` необходимо указать `DATABASE_URL` со строкой подключения к БД.
+
+### Docker Compose
+Для локального запуска PostgreSQL можно использовать `docker-compose`.
+Запустите контейнер командой:
+
+```bash
+docker-compose up -d
+```
+
+После запуска используйте строку подключения:
+
+```
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/playstar
+```
+
+


### PR DESCRIPTION
## Summary
- add docker-compose file with a PostgreSQL service
- document how to use docker-compose and connection string

## Testing
- `npm run`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873643550888325a1ee8b50bf914cb8