### PR TITLE
Add back navigation in wizard scene

### DIFF
--- a/src/scenes/partnerSearch.ts
+++ b/src/scenes/partnerSearch.ts
@@ -1,6 +1,7 @@
 import { Scenes, Markup } from 'telegraf';
 import { checkSubscription } from '../utils/checkSubscription';
 import { getArbitratorByReferralId } from '../db';
+import { menuKeyboard } from '../keyboards';
 
 export const partnerSearchScene = new Scenes.WizardScene<any>(
   'partnerSearch',
@@ -13,24 +14,68 @@ export const partnerSearchScene = new Scenes.WizardScene<any>(
     return ctx.wizard.next();
   },
   async (ctx) => {
+    if ((ctx.message as any)?.text === 'Назад') {
+      ctx.wizard.back();
+      await ctx.reply('Выберите игру', Markup.keyboard(['Game 1', 'Game 2']).oneTime().resize());
+      return;
+    }
     (ctx.wizard.state as any).game = (ctx.message as any)?.text;
-    await ctx.reply('Выберите возрастной диапазон', Markup.keyboard(['До 17', '18-22', '22-25', '25+']).oneTime().resize());
+    await ctx.reply(
+      'Выберите возрастной диапазон',
+      Markup.keyboard([
+        ['До 17', '18-22', '22-25', '25+'],
+        ['Назад']
+      ]).oneTime().resize()
+    );
     return ctx.wizard.next();
   },
   async (ctx) => {
+    if ((ctx.message as any)?.text === 'Назад') {
+      ctx.wizard.back();
+      await ctx.reply(
+        'Выберите возрастной диапазон',
+        Markup.keyboard([
+          ['До 17', '18-22', '22-25', '25+'],
+          ['Назад']
+        ]).oneTime().resize()
+      );
+      return;
+    }
     (ctx.wizard.state as any).age = (ctx.message as any)?.text;
-    await ctx.reply('Выберите уровень партнёрши', Markup.keyboard(['Базовый', 'Средний', 'Профессиональный']).oneTime().resize());
+    await ctx.reply(
+      'Выберите уровень партнёрши',
+      Markup.keyboard([
+        ['Базовый', 'Средний', 'Профессиональный'],
+        ['Назад']
+      ]).oneTime().resize()
+    );
     return ctx.wizard.next();
   },
   async (ctx) => {
+    if ((ctx.message as any)?.text === 'Назад') {
+      ctx.wizard.back();
+      await ctx.reply(
+        'Выберите уровень партнёрши',
+        Markup.keyboard([
+          ['Базовый', 'Средний', 'Профессиональный'],
+          ['Назад']
+        ]).oneTime().resize()
+      );
+      return;
+    }
     (ctx.wizard.state as any).skill = (ctx.message as any)?.text;
-    await ctx.reply('Укажите дату и время');
+    await ctx.reply('Укажите дату и время', Markup.keyboard([['Назад']]).resize());
     return ctx.wizard.next();
   },
   async (ctx) => {
+    if ((ctx.message as any)?.text === 'Назад') {
+      ctx.wizard.back();
+      await ctx.reply('Укажите дату и время', Markup.keyboard([['Назад']]).resize());
+      return;
+    }
     (ctx.wizard.state as any).datetime = (ctx.message as any)?.text;
     const summary = `Игра: ${(ctx.wizard.state as any).game}\nВозраст: ${(ctx.wizard.state as any).age}\nСкил: ${(ctx.wizard.state as any).skill}\nКогда: ${(ctx.wizard.state as any).datetime}`;
-    await ctx.reply(`Спасибо! Данные отправлены администратору.\n${summary}`);
+    await ctx.reply(`Спасибо! Данные отправлены администратору.\n${summary}`, menuKeyboard());
     let ref = '';
     if (ctx.session?.referralId) {
       const arbitrator = await getArbitratorByReferralId(ctx.session.referralId);


### PR DESCRIPTION
## Summary
- enable going back to previous steps in `partnerSearch` wizard
- return main menu after submitting a request

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68737af03a3c83258d8a9985379e9c60